### PR TITLE
Modify CODEOWNERS to adjust directory ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,5 +3,5 @@
 * @sin-city-programmers/admin
 
 # Exclude public and src directories from global ownership
-/public/
-/src/
+/apps/
+/libs/


### PR DESCRIPTION
Updated CODEOWNERS to include /apps and /libs directories while excluding /public and /src.