### PR TITLE
add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@ out-tsc
 # dependencies
 node_modules
 
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
 # IDEs and editors
 /.idea
 .project


### PR DESCRIPTION
## Description
Adds common environment variable 'Boiler Plate' file patterns to `.gitignore`

## Changes
- Added `.env` and related environment file patterns to `.gitignore`
- Covers local, development, test, and production environment files

## Why
Currently `.env` files are not ignored, which poses a security risk if developers accidentally commit files containing secrets.